### PR TITLE
[FIX] update setup.py for git dependency

### DIFF
--- a/setup/github_connector/setup.py
+++ b/setup/github_connector/setup.py
@@ -2,5 +2,11 @@ import setuptools
 
 setuptools.setup(
     setup_requires=['setuptools-odoo'],
-    odoo_addon=True,
+    odoo_addon={
+        'external_dependencies_override': {
+            'python': {
+                'git': 'gitpython',
+            },
+        },
+    },
 )


### PR DESCRIPTION
`import git` is provided by the `gitpython` distribution.

This is assuming gitpython is the correct one, which I'm not sure of. @legalsylvain can you confirm?

Closes #16 