### PR TITLE
[FIX] module icon resize problem

### DIFF
--- a/github_connector_odoo/models/odoo_module_version.py
+++ b/github_connector_odoo/models/odoo_module_version.py
@@ -342,7 +342,7 @@ class OdooModuleVersion(models.Model):
                 with open(icon_path, 'rb') as f:
                     image = f.read()
                 resized_image = tools.image_resize_image(
-                    image.encode('base64'), size=(96, 96),
+                    base64.b64encode(image), size=(96, 96),
                     encoding='base64', filetype='PNG')
             except Exception:
                 _logger.warning("Unable to read or resize %s" % icon_path)

--- a/github_connector_odoo/models/odoo_module_version.py
+++ b/github_connector_odoo/models/odoo_module_version.py
@@ -4,6 +4,7 @@
 
 import logging
 import os
+import base64
 
 from docutils.core import publish_string
 


### PR DESCRIPTION
problem was from 
https://github.com/OCA/interface-github/blob/11.0/github_connector_odoo/models/odoo_module_version.py#L345

when the icon as resized it was always having a warning log. and modules did not have the icon.
for tracing, I commented out the Try and except. and found that it was raising an error 
AttributeError: 'bytes' object has no attribute 'encode'
so with this PR, I have tried to solve the problem.