### PR TITLE
[FIX]do not delete module version if already exists and just update

### DIFF
--- a/github_connector_odoo/__manifest__.py
+++ b/github_connector_odoo/__manifest__.py
@@ -4,7 +4,7 @@
 {
     'name': 'Github Connector - Odoo',
     'summary': 'Analyze Odoo modules information from Github repositories',
-    'version': '11.0.1.2.0',
+    'version': '11.0.1.2.1',
     'category': 'Connector',
     'license': 'AGPL-3',
     'author': 'Odoo Community Association (OCA), Sylvain LE GAL, GRAP',
@@ -28,6 +28,7 @@
         'views/view_github_repository_branch.xml',
         'data/odoo_licence.xml',
         'data/odoo_category_data.xml',
+        'data/ir_cron.xml',
     ],
     'demo': [
         'demo/github_organization.xml',

--- a/github_connector_odoo/data/ir_cron.xml
+++ b/github_connector_odoo/data/ir_cron.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Copyright (C) 2016-Today: Odoo Community Association (OCA)
+@author: Sylvain LE GAL (https://twitter.com/legalsylvain)
+License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+-->
+<odoo noupdate="1">
+
+        <record model="ir.cron" id="cron_clean_odoo_module_version">
+            <field name="name">Clean Odoo Module Version</field>
+            <field name="interval_number">1</field>
+            <field name="active" eval="False"/>
+            <field name="user_id" ref="base.user_root"/>
+            <field name="interval_type">days</field>
+            <field name="numbercall">-1</field>
+            <field name="doall" eval="False"/>
+            <field name="state">code</field>
+            <field name="model_id" ref="model_odoo_module_version"/>
+            <field name="code">model.cron_clean_odoo_module_version()</field>
+        </record>
+
+</odoo>

--- a/github_connector_odoo/models/github_repository_branch.py
+++ b/github_connector_odoo/models/github_repository_branch.py
@@ -83,11 +83,6 @@ class GithubRepositoryBranch(models.Model):
         logger2.setLevel(logging.ERROR)
 
         try:
-            module_version_obj = self.env['odoo.module.version']
-            # Delete all associated module versions
-            module_versions = module_version_obj.search([
-                ('repository_branch_id', '=', branch.id)])
-
             # Compute path(s) to analyze
             if branch.module_paths:
                 paths = []

--- a/github_connector_odoo/models/github_repository_branch.py
+++ b/github_connector_odoo/models/github_repository_branch.py
@@ -87,8 +87,6 @@ class GithubRepositoryBranch(models.Model):
             # Delete all associated module versions
             module_versions = module_version_obj.search([
                 ('repository_branch_id', '=', branch.id)])
-            module_versions.with_context(
-                dont_change_repository_branch_state=True).unlink()
 
             # Compute path(s) to analyze
             if branch.module_paths:

--- a/github_connector_odoo/models/odoo_module_version.py
+++ b/github_connector_odoo/models/odoo_module_version.py
@@ -400,12 +400,24 @@ class OdooModuleVersion(models.Model):
     @api.multi
     def clean_odoo_module_version(self):
         for module_version in self:
-            module_ver_path = os.path.join(
-                module_version.repository_branch_id.local_path,
-                module_version.technical_name)
-            if os.path.exists(module_ver_path):
-                continue
-            module_version._process_clean_module_version()
+            # Compute path(s) to analyze
+            branch = module_version.repository_branch_id
+            if branch.module_paths:
+                paths = []
+                for path in branch.module_paths.split('\n'):
+                    if path.strip():
+                        paths.append(os.path.join(branch.local_path, path))
+            else:
+                paths = [branch.local_path]
+            found = False
+            for path in paths:
+                module_ver_path = os.path.join(
+                    path, module_version.technical_name)
+                if os.path.exists(module_ver_path):
+                    found = True
+                    continue
+            if not found:
+                module_version._process_clean_module_version()
         return True
 
     @api.multi

--- a/github_connector_odoo/models/odoo_module_version.py
+++ b/github_connector_odoo/models/odoo_module_version.py
@@ -391,3 +391,25 @@ class OdooModuleVersion(models.Model):
             except Exception as e:
                 _logger.error(
                     'Unable to read the OCA icon image, error is %s' % e)
+
+    @api.model
+    def cron_clean_odoo_module_version(self):
+        module_versions = self.search([])
+        module_versions.clean_odoo_module_version()
+
+    @api.multi
+    def clean_odoo_module_version(self):
+        for module_version in self:
+            module_ver_path = os.path.join(
+                module_version.repository_branch_id.local_path,
+                module_version.technical_name)
+            if os.path.exists(module_ver_path):
+                continue
+            module_version._process_clean_module_version()
+        return True
+
+    @api.multi
+    def _process_clean_module_version(self):
+        for module_version in self:
+            module_version.unlink()
+        return True

--- a/github_connector_odoo/models/odoo_module_version.py
+++ b/github_connector_odoo/models/odoo_module_version.py
@@ -401,14 +401,7 @@ class OdooModuleVersion(models.Model):
     def clean_odoo_module_version(self):
         for module_version in self:
             # Compute path(s) to analyze
-            branch = module_version.repository_branch_id
-            if branch.module_paths:
-                paths = []
-                for path in branch.module_paths.split('\n'):
-                    if path.strip():
-                        paths.append(os.path.join(branch.local_path, path))
-            else:
-                paths = [branch.local_path]
+            paths = module_version.repository_branch_id._get_module_paths()
             found = False
             for path in paths:
                 module_ver_path = os.path.join(


### PR DESCRIPTION
If Odoo module version already exists then instead of updating that version it is deleting and creating a new one.

Expected behaviour after this PR, It will not delete the existing version.

Updating the existing version functionality is already there 