### PR TITLE
[11.0][FIX] github_connector keyerror 'blog'

### DIFF
--- a/github_connector/README.rst
+++ b/github_connector/README.rst
@@ -242,6 +242,7 @@ Contributors
 * Sébastien BEAU (sebastien.beau@akretion.com)
 * Benoît GUILLOT (benoit.guillot@akretion.com)
 * Vicent Cubells (vicent.cubells@tecnativa.com)
+* Enrique Martín (enriquemartin@digital5.es)
 
 Maintainer
 ----------

--- a/github_connector/__manifest__.py
+++ b/github_connector/__manifest__.py
@@ -5,7 +5,7 @@
 {
     'name': 'Github Connector',
     'summary': 'Synchronize information from Github repositories',
-    'version': '11.0.1.1.1',
+    'version': '11.0.1.1.2',
     'category': 'Connector',
     'license': 'AGPL-3',
     'author':

--- a/github_connector/models/abstract_github_model.py
+++ b/github_connector/models/abstract_github_model.py
@@ -63,16 +63,30 @@ class AbstractGithubModel(models.AbstractModel):
             return self._github_login_field
 
     @api.model
+    def get_conversion_dict(self):
+        """
+        Prepare function that map Github fields to Odoo fields
+        :return: Dictionary {odoo_field: github_field}
+        """
+        """"""
+        return {
+            'github_id_external': 'id',
+            'github_url': 'html_url',
+            'github_login': self.github_login_field(),
+            'github_create_date': 'created_at',
+            'github_write_date': 'updated_at',
+        }
+
+    @api.model
     def get_odoo_data_from_github(self, data):
         """Prepare function that map Github data to create in Odoo"""
-        return {
-            'github_id_external': data['id'],
-            'github_url': data.get('html_url', False),
-            'github_login': data.get(self.github_login_field(), False),
-            'github_create_date': data.get('created_at', False),
-            'github_write_date': data.get('updated_at', False),
-            'github_last_sync_date': fields.Datetime.now(),
-        }
+        map_dict = self.get_conversion_dict()
+        res = {}
+        for k, v in map_dict.items():
+            if hasattr(self, k) and data.get(v, False):
+                res.update({k: data[v]})
+        res.update({'github_last_sync_date': fields.Datetime.now()})
+        return res
 
     @api.multi
     def get_github_data_from_odoo(self):

--- a/github_connector/models/abstract_github_model.py
+++ b/github_connector/models/abstract_github_model.py
@@ -68,7 +68,6 @@ class AbstractGithubModel(models.AbstractModel):
         Prepare function that map Github fields to Odoo fields
         :return: Dictionary {odoo_field: github_field}
         """
-        """"""
         return {
             'github_id_external': 'id',
             'github_url': 'html_url',

--- a/github_connector/models/github_organization.py
+++ b/github_connector/models/github_organization.py
@@ -77,14 +77,14 @@ class GithubOrganization(models.Model):
     @api.model
     def get_odoo_data_from_github(self, data):
         res = super(GithubOrganization, self).get_odoo_data_from_github(data)
-		res.update({
+        res.update({
             'name': data['name'],
             'description': data['description'],
             'location': data['location'],
             'website_url': data['blog'],
             'email': data['email'],
             'image': self.get_base64_image_from_github(data['avatar_url']),
-		})
+        })
         return res
 
     @api.multi

--- a/github_connector/models/github_organization.py
+++ b/github_connector/models/github_organization.py
@@ -75,16 +75,24 @@ class GithubOrganization(models.Model):
 
     # Overloadable Section
     @api.model
+    def get_conversion_dict(self):
+        res = super(GithubOrganization, self).get_conversion_dict()
+        res.update({
+            'name': 'name',
+            'description': 'description',
+            'location': 'location',
+            'email': 'email',
+            'website_url': 'blog',
+        })
+        return res
+
+    @api.model
     def get_odoo_data_from_github(self, data):
         res = super(GithubOrganization, self).get_odoo_data_from_github(data)
-        res.update({
-            'name': data['name'],
-            'description': data['description'],
-            'location': data['location'],
-            'website_url': data['blog'],
-            'email': data['email'],
-            'image': self.get_base64_image_from_github(data['avatar_url']),
-        })
+        if 'avatar_url' in data:
+            res.update({
+                'image': self.get_base64_image_from_github(data['avatar_url']),
+            })
         return res
 
     @api.multi

--- a/github_connector/models/github_organization.py
+++ b/github_connector/models/github_organization.py
@@ -25,6 +25,8 @@ class GithubOrganization(models.Model):
 
     website_url = fields.Char(string='Website URL', readonly=True)
 
+    blog = fields.Char(string='Blog URL', readonly=True)
+
     location = fields.Char(string='Location', readonly=True)
 
     ignored_repository_names = fields.Text(

--- a/github_connector/models/github_organization.py
+++ b/github_connector/models/github_organization.py
@@ -25,8 +25,6 @@ class GithubOrganization(models.Model):
 
     website_url = fields.Char(string='Website URL', readonly=True)
 
-    blog = fields.Char(string='Blog URL', readonly=True)
-
     location = fields.Char(string='Location', readonly=True)
 
     ignored_repository_names = fields.Text(
@@ -79,14 +77,14 @@ class GithubOrganization(models.Model):
     @api.model
     def get_odoo_data_from_github(self, data):
         res = super(GithubOrganization, self).get_odoo_data_from_github(data)
-        keys = ['name', 'description', 'location', 'blog', 'email']
-        for key in keys:
-            if key in data:
-                res.update({key: data[key]})
-        if 'avatar_url' in data:
-            res.update({
-                'image': self.get_base64_image_from_github(data['avatar_url']),
-            })
+		res.update({
+            'name': data['name'],
+            'description': data['description'],
+            'location': data['location'],
+            'website_url': data['blog'],
+            'email': data['email'],
+            'image': self.get_base64_image_from_github(data['avatar_url']),
+		})
         return res
 
     @api.multi

--- a/github_connector/models/github_repository.py
+++ b/github_connector/models/github_repository.py
@@ -92,15 +92,22 @@ class GithubRepository(models.Model):
 
     # Overloadable Section
     @api.model
+    def get_conversion_dict(self):
+        res = super(GithubRepository, self).get_conversion_dict()
+        res.update({
+            'name': 'name',
+            'github_url': 'url',
+            'description': 'description',
+            'website': 'homepage',
+        })
+        return res
+
+    @api.model
     def get_odoo_data_from_github(self, data):
         organization_obj = self.env['github.organization']
         res = super(GithubRepository, self).get_odoo_data_from_github(data)
         organization = organization_obj.get_from_id_or_create(data['owner'])
         res.update({
-            'name': data['name'],
-            'github_url': data['url'],
-            'description': data['description'],
-            'website': data['homepage'],
             'organization_id': organization.id,
         })
         return res

--- a/github_connector/models/github_team.py
+++ b/github_connector/models/github_team.py
@@ -93,6 +93,17 @@ class GithubTeam(models.Model):
             team.repository_qty = len(team.repository_ids)
 
     # Overloadable Section
+    @api.model
+    def get_conversion_dict(self):
+        res = super(GithubTeam, self).get_conversion_dict()
+        res.update({
+            'name': 'name',
+            'description': 'description',
+            'privacy': 'privacy',
+        })
+        return res
+
+    @api.model
     def get_odoo_data_from_github(self, data):
         organization_obj = self.env['github.organization']
         res = super(GithubTeam, self).get_odoo_data_from_github(data)
@@ -102,9 +113,6 @@ class GithubTeam(models.Model):
         else:
             organization_id = False
         res.update({
-            'name': data['name'],
-            'description': data['description'],
-            'privacy': data['privacy'],
             'organization_id': organization_id,
         })
         return res

--- a/github_connector/models/res_partner.py
+++ b/github_connector/models/res_partner.py
@@ -68,14 +68,24 @@ class ResPartner(models.Model):
 
     # Custom Section
     @api.model
+    def get_conversion_dict(self):
+        res = super(ResPartner, self).get_conversion_dict()
+        res.update({
+            'website': 'blog',
+            'email': 'email',
+        })
+        return res
+
+    @api.model
     def get_odoo_data_from_github(self, data):
         res = super(ResPartner, self).get_odoo_data_from_github(data)
         res.update({
             'name':
             data['name'] and data['name'] or
             '%s (Github)' % data['login'],
-            'website': data['blog'],
-            'email': data['email'],
-            'image': self.get_base64_image_from_github(data['avatar_url']),
         })
+        if 'avatar_url' in data:
+            res.update({
+                'image': self.get_base64_image_from_github(data['avatar_url']),
+            })
         return res

--- a/github_connector/views/view_github_organization.xml
+++ b/github_connector/views/view_github_organization.xml
@@ -76,6 +76,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                     <group col="4">
                         <field name="email" widget="email"/>
                         <field name="website_url" widget="url"/>
+                        <field name="blog" widget="url"/>
                         <field name="location"/>
                     </group>
                     <notebook>

--- a/github_connector/views/view_github_organization.xml
+++ b/github_connector/views/view_github_organization.xml
@@ -76,7 +76,6 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                     <group col="4">
                         <field name="email" widget="email"/>
                         <field name="website_url" widget="url"/>
-                        <field name="blog" widget="url"/>
                         <field name="location"/>
                     </group>
                     <notebook>


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

On new database error when syncing new github organization (example: OCA).
Error traceback: KeyError: 'blog'

![imagen](https://user-images.githubusercontent.com/1880221/51923799-fb2fa080-23eb-11e9-829c-6a54a8d82941.png)

**Current behavior before PR:**

Synchronization gets blog key on `get_odoo_data_from_github` but blog field does not exist.
When it tries to match the key with model attribute we get key error.

**Desired behavior after PR is merged:**

Get blog key from github data and show it on form view.