### PR TITLE
12.0 fix dep

### DIFF
--- a/github_connector/__manifest__.py
+++ b/github_connector/__manifest__.py
@@ -46,6 +46,6 @@
     ],
     'installable': True,
     'external_dependencies': {
-        'python': ['gitpython'],
+        'python': ['GitPython'],
     },
 }

--- a/github_connector/__manifest__.py
+++ b/github_connector/__manifest__.py
@@ -46,6 +46,6 @@
     ],
     'installable': True,
     'external_dependencies': {
-        'python': ['git'],
+        'python': ['gitpython'],
     },
 }

--- a/github_connector/setup/.setuptools-odoo-make-default-ignore
+++ b/github_connector/setup/.setuptools-odoo-make-default-ignore
@@ -1,0 +1,2 @@
+# addons listed in this file are ignored by
+# setuptools-odoo-make-default (one addon per line)

--- a/github_connector/setup/README
+++ b/github_connector/setup/README
@@ -1,0 +1,2 @@
+To learn more about this directory, please visit
+https://pypi.python.org/pypi/setuptools-odoo


### PR DESCRIPTION
Perhaps is my fault, but the only way to install `github_connector` was change dep from `git` to `gitpython`