### PR TITLE
[FIX] search for archived records when synchronizing

### DIFF
--- a/github_connector/models/abstract_github_model.py
+++ b/github_connector/models/abstract_github_model.py
@@ -143,8 +143,9 @@ class AbstractGithubModel(models.AbstractModel):
 
         # We try to see if object exist by name (instead of id)
         if self._github_login_field and self._github_login_field in data:
-            existing_object = self.search([
-                ('github_login', '=', data[self._github_login_field])])
+            existing_object = self.with_context(active_test=False).search(
+                [('github_login', '=', data[self._github_login_field])]
+            )
             if len(existing_object) == 1:
                 # Update the existing object with the id
                 existing_object.github_id_external = data['id']

--- a/github_connector_odoo/models/github_repository.py
+++ b/github_connector_odoo/models/github_repository.py
@@ -27,8 +27,8 @@ class GithubRepository(models.Model):
         for organization_id, repositories in url_done.items():
             if organization_id.runbot_parse_url:
                 runbot_list = urlopen(
-                    Request(
-                        organization_id.runbot_parse_url)).read().split('\n')
+                    Request(organization_id.runbot_parse_url)
+                ).read().decode().split('\n')
                 for item in runbot_list:
                     for repository in repositories:
                         if item.endswith(repository.complete_name):


### PR DESCRIPTION
In the OCA database, for instance, there are archived
partners, which still have their github login set.
This raises unique key error when the constraint
on github_login is properly in place.
