### PR TITLE
[FIX] github_connector: Ensure source path exists always

### DIFF
--- a/github_connector/models/github_repository_branch.py
+++ b/github_connector/models/github_repository_branch.py
@@ -86,6 +86,13 @@ class GithubRepository(models.Model):
     # Init Section
     def __init__(self, pool, cr):
         source_path = tools.config.get('source_code_local_path', False)
+        if not os.path.exists(source_path):
+            try:
+                os.makedirs(source_path)
+            except Exception as e:
+                _logger.error(_(
+                    "Error when trying to create the main folder %s\n"
+                    " Please check Odoo Access Rights.\n %s"), source_path, e)
         if source_path and source_path not in modules.module.ad_paths:
             modules.module.ad_paths.append(source_path)
         super(GithubRepository, self).__init__(pool, cr)


### PR DESCRIPTION
If source path does not exists before adding it to modules path, styles
on website are corrupted, making impossible load them from assets.


![image](https://user-images.githubusercontent.com/10233975/65344299-f0a16180-db9c-11e9-84e9-5b7d46c3829f.png)
