### PR TITLE
[12.0][IMP] introduce usage of github_token and private cloning

### DIFF
--- a/github_connector/README.rst
+++ b/github_connector/README.rst
@@ -22,9 +22,11 @@ Once installed, you have to:
    credentials, and the local path where the source code will be downloaded:
 
    * ``source_code_local_path = /workspace/source_code/``
+
 Note: make sure that Odoo process has read / write access on that folder
 
    * ``github_token = your_github_access_token``
+
 or
    * ``github_login = your_github_login``
    * ``github_password = your_github_password``

--- a/github_connector/README.rst
+++ b/github_connector/README.rst
@@ -21,11 +21,16 @@ Once installed, you have to:
 #. Open your odoo.conf file and add extra settings to mention Github
    credentials, and the local path where the source code will be downloaded:
 
+   * ``source_code_local_path = /workspace/source_code/``
+Note: make sure that Odoo process has read / write access on that folder
+
+   * ``github_token = your_github_access_token``
+or
    * ``github_login = your_github_login``
    * ``github_password = your_github_password``
-   * ``source_code_local_path = /workspace/source_code/``
 
-   Note: make sure that Odoo process has read / write access on that folder
+Note: if token and login/password are provided, the token will be used.
+
 
 #. Go to 'Settings' / 'Technical' / 'Parameters' / 'System Parameters'
    and define the following values:

--- a/github_connector/models/abstract_github_model.py
+++ b/github_connector/models/abstract_github_model.py
@@ -159,7 +159,7 @@ class AbstractGithubModel(models.AbstractModel):
             elif len(existing_object) > 1:
                 raise UserError(
                     _("Duplicate object with Github login %s") %
-                    (data[self._github_login_field], ))
+                    (data[self._github_login_field],))
 
         if self._need_individual_call:
             github_connector = self.get_github_connector(self.github_type())
@@ -263,8 +263,8 @@ class AbstractGithubModel(models.AbstractModel):
     @api.multi
     def get_github_connector(self, github_type):
         no_login = (
-                not tools.config.get('github_login')
-                or not tools.config.get('github_password')
+            not tools.config.get('github_login') or
+            not tools.config.get('github_password')
         )
         no_token = not tools.config.get('github_token')
         if no_login and no_token:

--- a/github_connector/models/abstract_github_model.py
+++ b/github_connector/models/abstract_github_model.py
@@ -277,7 +277,9 @@ class AbstractGithubModel(models.AbstractModel):
             login=tools.config.get('github_login', ""),
             password=tools.config.get('github_password', ""),
             # or 1 to avoid the raise of an error on None
-            max_try=int(self.sudo().env['ir.config_parameter'].get_param('github.max_try') or 1),
+            max_try=int(
+                self.sudo().env['ir.config_parameter'].get_param('github.max_try') or 1
+            ),
             token=tools.config.get('github_token', "")
         )
 

--- a/github_connector/models/abstract_github_model.py
+++ b/github_connector/models/abstract_github_model.py
@@ -275,9 +275,9 @@ class AbstractGithubModel(models.AbstractModel):
         return Github(
             github_type,
             int(self.sudo().env['ir.config_parameter'].get_param('github.max_try')),
-            login=tools.config.get('github_login'),
-            password=tools.config.get('github_password'),
-            token=tools.config.get('github_token'),
+            login=tools.config.get('github_login', ""),
+            password=tools.config.get('github_password', ""),
+            token=tools.config.get('github_token', ""),
         )
 
     @api.multi

--- a/github_connector/models/abstract_github_model.py
+++ b/github_connector/models/abstract_github_model.py
@@ -276,7 +276,8 @@ class AbstractGithubModel(models.AbstractModel):
             github_type,
             login=tools.config.get('github_login', ""),
             password=tools.config.get('github_password', ""),
-            max_try=int(self.sudo().env['ir.config_parameter'].get_param('github.max_try')),
+            # or 1 to avoid the raise of an error on None
+            max_try=int(self.sudo().env['ir.config_parameter'].get_param('github.max_try') or 1),
             token=tools.config.get('github_token', "")
         )
 

--- a/github_connector/models/abstract_github_model.py
+++ b/github_connector/models/abstract_github_model.py
@@ -274,10 +274,10 @@ class AbstractGithubModel(models.AbstractModel):
                 " in Odoo configuration file."))
         return Github(
             github_type,
-            int(self.sudo().env['ir.config_parameter'].get_param('github.max_try')),
             login=tools.config.get('github_login', ""),
             password=tools.config.get('github_password', ""),
-            token=tools.config.get('github_token', ""),
+            max_try=int(self.sudo().env['ir.config_parameter'].get_param('github.max_try')),
+            token=tools.config.get('github_token', "")
         )
 
     @api.multi

--- a/github_connector/models/abstract_github_model.py
+++ b/github_connector/models/abstract_github_model.py
@@ -262,17 +262,21 @@ class AbstractGithubModel(models.AbstractModel):
 
     @api.multi
     def get_github_connector(self, github_type):
-        if (not tools.config.get('github_login') or
-                not tools.config.get('github_password')):
+        no_login = not tools.config.get('github_login')\
+                   or not tools.config.get('github_password')
+        no_token = not tools.config.get('github_token')
+        if no_login and no_token:
             raise exceptions.Warning(_(
-                "Please add 'github_login' and 'github_password' "
-                "in Odoo configuration file."))
+                "Please add the couple 'github_login' and 'github_password'"
+                " or 'github_token'"
+                " in Odoo configuration file."))
         return Github(
             github_type,
-            tools.config['github_login'],
-            tools.config['github_password'],
-            int(self.sudo().env['ir.config_parameter'].get_param(
-                'github.max_try')))
+            int(self.sudo().env['ir.config_parameter'].get_param('github.max_try')),
+            login=tools.config.get('github_login'),
+            password=tools.config.get('github_password'),
+            token=tools.config.get('github_token'),
+        )
 
     @api.multi
     def create_in_github(self, model_obj):

--- a/github_connector/models/abstract_github_model.py
+++ b/github_connector/models/abstract_github_model.py
@@ -262,8 +262,10 @@ class AbstractGithubModel(models.AbstractModel):
 
     @api.multi
     def get_github_connector(self, github_type):
-        no_login = not tools.config.get('github_login')\
-                   or not tools.config.get('github_password')
+        no_login = (
+                not tools.config.get('github_login')
+                or not tools.config.get('github_password')
+        )
         no_token = not tools.config.get('github_token')
         if no_login and no_token:
             raise exceptions.Warning(_(

--- a/github_connector/models/github.py
+++ b/github_connector/models/github.py
@@ -183,6 +183,7 @@ class Github(object):
         return self.get_by_url(url, 'get')
 
     def create(self, arguments, data):
+        # pylint: disable=method-required-super
         url = self._build_url(arguments, 'url_create', None)
         res = self.get_by_url(url, 'post', data)
         return res

--- a/github_connector/models/github.py
+++ b/github_connector/models/github.py
@@ -100,7 +100,9 @@ class Github(object):
 
         :rtype: string
         """
-        identification = self.token if self.token else ":".join([self.login, self.password])
+        identification = (
+            self.token if self.token else ":".join([self.login, self.password])
+        )
         return "https://{}@github.com/".format(identification)
 
     def list(self, arguments):
@@ -131,7 +133,10 @@ class Github(object):
             raise exceptions.Warning(_('Maximum attempts reached.'))
 
         # display an anonymize token or the login
-        login = self.token and "* * * * * * * * {}".format(self.token[-4:]) or self.login
+        login = (
+                self.token and "* * * * * * * * {}".format(self.token[-4:])
+                or self.login
+        )
         if response.status_code == _CODE_401:
             raise exceptions.Warning(_(
                 "401 - Unable to authenticate to Github with the login '%s'.\n"
@@ -155,7 +160,9 @@ class Github(object):
         return response.json()
 
     def get_request_function(self, call_type):
-        """ Return the request function to use depending on the call_type and the identification type.
+        """ Return the request function to use depending on the call_type and the
+        identification type.
+
 
         :param str call_type: CRUD method. Can be get or post.
         :rtype: callable
@@ -165,8 +172,8 @@ class Github(object):
             "`{}` is not a supported CRUD method. Use one of the following {}".format(
                 call_type, supported_crud_methods
         )
-        # We want the same signature for all the functions returned to ease the usage. The caller should not have to
-        # consider cases. Cases are handled here.
+        # We want the same signature for all the functions returned to ease the usage.
+        # The caller should not have to # consider cases. Cases are handled here.
 
         if self.token:
             # When an access token is used, the token has to be passed using a headers.

--- a/github_connector/models/github.py
+++ b/github_connector/models/github.py
@@ -134,8 +134,8 @@ class Github(object):
 
         # display an anonymize token or the login
         login = (
-                self.token and "* * * * * * * * {}".format(self.token[-4:])
-                or self.login
+            self.token and "* * * * * * * * {}".format(self.token[-4:])
+            or self.login
         )
         if response.status_code == _CODE_401:
             raise exceptions.Warning(_(
@@ -168,10 +168,10 @@ class Github(object):
         :rtype: callable
         """
         supported_crud_methods = ('get', 'post')
-        assert call_type in supported_crud_methods, \
-            "`{}` is not a supported CRUD method. Use one of the following {}".format(
-                call_type, supported_crud_methods
+        msg = "`{}` is not a supported CRUD method. Use one of the following {}".format(
+            call_type, supported_crud_methods
         )
+        assert call_type in supported_crud_methods, msg
         # We want the same signature for all the functions returned to ease the usage.
         # The caller should not have to # consider cases. Cases are handled here.
 

--- a/github_connector/models/github.py
+++ b/github_connector/models/github.py
@@ -124,12 +124,20 @@ class Github(object):
             try:
                 if self.token:
                     headers = {'Authorization': 'token {}'.format(self.token)}
-                    get = lambda u: requests.get(u, headers=headers)
-                    post = lambda u, d: requests.get(u ,headers=headers, data=d)
+
+                    def get(u):
+                        return requests.get(u, headers=headers)
+
+                    def post(u, d):
+                        return requests.get(u, headers=headers, data=d)
                 else:
                     auth = HTTPBasicAuth(self.login, self.password)
-                    get = lambda u: requests.get(u, auth=auth)
-                    post = lambda u, d: requests.get(u, auth=auth, data=d)
+
+                    def get(u):
+                        return requests.get(u, auth=auth)
+
+                    def post(u, d):
+                        return requests.get(u, auth=auth, data=d)
 
                 if call_type == 'get':
                     response = get(url)

--- a/github_connector/models/github.py
+++ b/github_connector/models/github.py
@@ -74,13 +74,13 @@ _CODE_201 = 201
 
 class Github(object):
 
-    def __init__(self, github_type, max_try, login="", password="", token=""):
+    def __init__(self, github_type, login, password, max_try, token=""):
         super(Github, self).__init__()
         self.github_type = github_type
-        self.token = token
         self.login = login
         self.password = password
         self.max_try = max_try
+        self.token = token
 
     def _build_url(self, arguments, url_type, page):
         arguments = arguments and arguments or {}
@@ -147,14 +147,15 @@ class Github(object):
                     response = post(url, json_data)
                     break
             except Exception as err:
-                _logger.exception(
+                _logger.warning(
                     "URL Call Error. %d/%d. URL: %s",
                     i, self.max_try, err.__str__(),
                 )
         else:
             raise exceptions.Warning(_('Maximum attempts reached.'))
 
-        login = self.token or self.login
+        # display an anonymize token or the login
+        login = self.token and "* * * * * * * * {}".format(self.token[-4:]) or self.login
         if response.status_code == _CODE_401:
             raise exceptions.Warning(_(
                 "401 - Unable to authenticate to Github with the login '%s'.\n"

--- a/github_connector/models/github_repository_branch.py
+++ b/github_connector/models/github_repository_branch.py
@@ -129,6 +129,7 @@ class GithubRepository(models.Model):
 
     @api.multi
     def _download_code(self):
+        client = self.get_github_connector("")
         for branch in self:
             if not os.path.exists(branch.local_path):
                 _logger.info(
@@ -144,7 +145,7 @@ class GithubRepository(models.Model):
 
                 command = (
                     "git clone %s%s/%s.git -b %s %s") % (
-                        _GITHUB_URL,
+                        client.get_http_url(),
                         branch.repository_id.organization_id.github_login,
                         branch.repository_id.name,
                         branch.name,

--- a/github_connector/models/github_repository_branch.py
+++ b/github_connector/models/github_repository_branch.py
@@ -8,7 +8,6 @@ import os
 from subprocess import check_output
 from datetime import datetime
 
-from .github import _GITHUB_URL
 from odoo import _, api, exceptions, fields, models, modules, tools
 from odoo.tools.safe_eval import safe_eval
 

--- a/github_connector_odoo/models/github_repository_branch.py
+++ b/github_connector_odoo/models/github_repository_branch.py
@@ -129,7 +129,7 @@ class GithubRepositoryBranch(models.Model):
                 if os.path.isfile(opj(folder, name, mname)):
                     return True
 
-        return map(clean, filter(is_really_module, os.listdir(dir)))
+        return map(clean, filter(is_really_module, os.listdir(folder)))
 
     def _analyze_module_name(self, path, module_name):
         self.ensure_one()

--- a/github_connector_odoo/models/github_repository_branch.py
+++ b/github_connector_odoo/models/github_repository_branch.py
@@ -106,7 +106,7 @@ class GithubRepositoryBranch(models.Model):
                 else:
                     # Analyze folders and create module versions
                     _logger.info("Analyzing repository %s ...", path)
-                    for module_name in self.listdir(path):
+                    for module_name in self.list_dir(path):
                         self._analyze_module_name(path, module_name)
         finally:
             # Reset Original level for module logger

--- a/github_connector_odoo/models/github_repository_branch.py
+++ b/github_connector_odoo/models/github_repository_branch.py
@@ -117,7 +117,7 @@ class GithubRepositoryBranch(models.Model):
     # Copy Paste from Odoo Core
     # This function is for the time being in another function.
     # (Ref: openerp/modules/module.py)
-    def listdir(self, dir):
+    def list_dir(self, folder):
         def clean(name):
             name = os.path.basename(name)
             if name[-4:] == '.zip':
@@ -126,7 +126,7 @@ class GithubRepositoryBranch(models.Model):
 
         def is_really_module(name):
             for mname in MANIFEST_NAMES:
-                if os.path.isfile(opj(dir, name, mname)):
+                if os.path.isfile(opj(folder, name, mname)):
                     return True
 
         return map(clean, filter(is_really_module, os.listdir(dir)))


### PR DESCRIPTION
This commit introduces the usage of github access token in parallel of github login/password.
On top of it, it introduces the cloning of private repositories that the credentials allows.

work on #21 