### PR TITLE
[12.0][IMP] github_connector*: Make module_paths on repository branch field functional

### DIFF
--- a/github_connector/models/github_repository_branch.py
+++ b/github_connector/models/github_repository_branch.py
@@ -192,12 +192,11 @@ class GithubRepository(models.Model):
                         res.append(os.path.join(root, fic))
         return res
 
-    @api.model
-    def analyze_code_one(self, branch):
+    def analyze_code_one(self):
         """Overload Me in custom Module that manage Source Code analysis.
         """
         self.ensure_one()
-        path = branch.local_path
+        path = self.local_path
         # Compute Files Sizes
         size = 0
         for file_path in self._get_analyzable_files(path):
@@ -230,7 +229,7 @@ class GithubRepository(models.Model):
             else:
                 _logger.info("Analyzing Source Code in %s ...", path)
                 try:
-                    vals = branch.analyze_code_one(branch)
+                    vals = branch.analyze_code_one()
                     vals.update({
                         'last_analyze_date': datetime.today(),
                         'state': 'analyzed',

--- a/github_connector/views/view_github_repository_branch.xml
+++ b/github_connector/views/view_github_repository_branch.xml
@@ -112,10 +112,14 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                             </group>
                         </page>
                         <page name="technical" string="Technical Settings">
-                            <group col="4">
-                                <field name="local_path" colspan="4"/>
-                                <field name="last_download_date"/>
-                                <field name="last_analyze_date"/>
+                            <group>
+                                <group name="group_technical_paths">
+                                    <field name="local_path"/>
+                                </group>
+                                <group name="group_technical_dates">
+                                    <field name="last_download_date"/>
+                                    <field name="last_analyze_date"/>
+                                </group>
                             </group>
                         </page>
                     </notebook>

--- a/github_connector_odoo/views/view_github_repository_branch.xml
+++ b/github_connector_odoo/views/view_github_repository_branch.xml
@@ -31,6 +31,9 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
             <field name="ci_url" position="after">
                 <field name="runbot_url" widget="url" colspan="4"/>
             </field>
+            <group name="group_technical_paths" position="inside">
+                <field name="module_paths"/>
+            </group>
         </field>
     </record>
 


### PR DESCRIPTION
This field allows to define where addons are located, but it's hidden right now, because
not everything is properly adjusted for paths different from root.

Making this working, there's no need to hide the field.

It includes also an extra commit that homogenize a bit the API for the methods, avoiding an extra useless argument.

cc @Tecnativa TT20539