### PR TITLE
[12.0][FIX] security issue. authentification information are communicated

### DIFF
--- a/github_connector/data/ir_config_parameter.xml
+++ b/github_connector/data/ir_config_parameter.xml
@@ -16,4 +16,9 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
         <field name="value">True</field>
     </record>
 
+    <record id="github_unsecure" model="ir.config_parameter">
+        <field name="key">github.unsecure</field>
+        <field name="value">False</field>
+    </record>
+
 </odoo>

--- a/github_connector/models/github.py
+++ b/github_connector/models/github.py
@@ -95,7 +95,7 @@ class Github(object):
                 'per_page=%d&page=%d' % (_MAX_NUMBER_REQUEST, page)
         return complete_url
 
-    def get_http_url(self):
+    def get_http_url(self, unsecure=False):
         """ Returns the http url to github with the identifications
 
         :rtype: string
@@ -103,7 +103,10 @@ class Github(object):
         identification = (
             self.token if self.token else ":".join([self.login, self.password])
         )
-        return "https://{}@github.com/".format(identification)
+        if unsecure:
+            return "https://{}@github.com/".format(identification)
+        else:
+            return _GITHUB_URL
 
     def list(self, arguments):
         page = 1

--- a/github_connector/models/github_repository_branch.py
+++ b/github_connector/models/github_repository_branch.py
@@ -130,8 +130,8 @@ class GithubRepository(models.Model):
     @api.multi
     def _download_code(self):
         client = self.get_github_connector("")
-        unsecure = self.sudo().env['ir.config_parameter'].get_param(
-            'github.unsecure', False)
+        unsecure = bool(self.sudo().env['ir.config_parameter'].get_param(
+            'github.unsecure', False))
         for branch in self:
             if not os.path.exists(branch.local_path):
                 _logger.info(

--- a/github_connector/models/github_repository_branch.py
+++ b/github_connector/models/github_repository_branch.py
@@ -130,6 +130,8 @@ class GithubRepository(models.Model):
     @api.multi
     def _download_code(self):
         client = self.get_github_connector("")
+        unsecure = self.sudo().env['ir.config_parameter'].get_param(
+            'github.unsecure', False)
         for branch in self:
             if not os.path.exists(branch.local_path):
                 _logger.info(
@@ -145,7 +147,7 @@ class GithubRepository(models.Model):
 
                 command = (
                     "git clone %s%s/%s.git -b %s %s") % (
-                        client.get_http_url(),
+                        client.get_http_url(unsecure),
                         branch.repository_id.organization_id.github_login,
                         branch.repository_id.name,
                         branch.name,

--- a/github_connector/security/res_groups.xml
+++ b/github_connector/security/res_groups.xml
@@ -6,17 +6,17 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 -->
 <odoo>
 
-    <record id="base.group_no_one" model="res.groups">
-        <field name="users" eval="[(4, ref('base.user_root'))]"/>
-    </record>
     <record id="group_github_connector_user" model="res.groups">
         <field name="name">Connector Github User</field>
         <field name="category_id" ref="module_category_github_connector"/>
     </record>
+
     <record id="group_github_connector_manager" model="res.groups">
         <field name="name">Connector Github Manager</field>
         <field name="category_id" ref="module_category_github_connector"/>
-        <field name="users" eval="[(4, ref('base.user_root'))]"/>
+        <field name="users" eval="[
+            (4, ref('base.user_root')),
+            (4, ref('base.user_admin'))]"/>
         <field name="implied_ids" eval="[(4, ref('github_connector.group_github_connector_user'))]"/>
     </record>
 


### PR DESCRIPTION
Hi all,

This PR https://github.com/OCA/interface-github/pull/44 and more specifically, this commit https://github.com/OCA/interface-github/commit/b4728284618e6c6d11ab33832dc47d5db9f08222#diff-0926d9378a3e95d64ac7ece9ee4e4719R98 is introducing a security issue on the module interface-github. The token or the couple login - password are communnicated clearly in the url.
So, it is possible to get this information, listening the network. (ISP, others).

This is a quick patch to fix it. More deep refactoring could be done in a second time for exemple, using github3.py library instead of calling APi directly.

@foutoucour 

CC : @pedrobaeza, @gurneyalex 

@tardo : could you cherry pick this commits, once merged here ? https://github.com/OCA/interface-github/pull/47 thanks.


