### PR TITLE
[FIX] github_connector_odoo: Repository branch modules button error

### DIFF
--- a/github_connector_odoo/models/__init__.py
+++ b/github_connector_odoo/models/__init__.py
@@ -1,3 +1,4 @@
+from . import abstract_action_mixin
 from . import odoo_author
 from . import odoo_category
 from . import odoo_license

--- a/github_connector_odoo/models/abstract_action_mixin.py
+++ b/github_connector_odoo/models/abstract_action_mixin.py
@@ -1,0 +1,18 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import models
+
+
+class AbstractActionMixin(models.AbstractModel):
+    _name = "abstract.action.mixin"
+    _description = "Abstract Action Mixin"
+
+    def action_open(self):
+        self.ensure_one()
+        action = self.env.ref(
+            "github_connector_odoo.%s" % self._context.get("xml_id")
+        ).read()[0]
+        action["context"] = dict(self.env.context)
+        action["context"].pop("group_by", None)
+        action["context"]["search_default_" + self._context.get("field_name")] = self.id
+        return action

--- a/github_connector_odoo/models/github_repository_branch.py
+++ b/github_connector_odoo/models/github_repository_branch.py
@@ -17,7 +17,8 @@ _logger = logging.getLogger(__name__)
 
 
 class GithubRepositoryBranch(models.Model):
-    _inherit = ["github.repository.branch"]
+    _inherit = ["github.repository.branch", "abstract.action.mixin"]
+    _name = "github.repository.branch"
 
     module_paths = fields.Text(
         string="Module Paths",

--- a/github_connector_odoo/models/odoo_author.py
+++ b/github_connector_odoo/models/odoo_author.py
@@ -6,6 +6,7 @@ from odoo import api, fields, models
 
 
 class OdooAuthor(models.Model):
+    _inherit = "abstract.action.mixin"
     _name = "odoo.author"
     _description = "Odoo Author"
     _order = "module_qty desc, name"

--- a/github_connector_odoo/models/odoo_lib_bin.py
+++ b/github_connector_odoo/models/odoo_lib_bin.py
@@ -6,6 +6,7 @@ from odoo import api, fields, models
 
 
 class OdooLibBin(models.Model):
+    _inherit = "abstract.action.mixin"
     _name = "odoo.lib.bin"
     _description = "Odoo Lib Bin"
     _order = "module_version_qty desc"

--- a/github_connector_odoo/models/odoo_lib_python.py
+++ b/github_connector_odoo/models/odoo_lib_python.py
@@ -6,6 +6,7 @@ from odoo import api, fields, models
 
 
 class OdooLibPython(models.Model):
+    _inherit = "abstract.action.mixin"
     _name = "odoo.lib.python"
     _description = "Odoo Lib Python"
     _order = "module_version_qty desc"

--- a/github_connector_odoo/models/odoo_license.py
+++ b/github_connector_odoo/models/odoo_license.py
@@ -6,6 +6,7 @@ from odoo import api, fields, models
 
 
 class OdooLicense(models.Model):
+    _inherit = "abstract.action.mixin"
     _name = "odoo.license"
     _description = "Odoo License"
     _order = "name"

--- a/github_connector_odoo/models/odoo_module.py
+++ b/github_connector_odoo/models/odoo_module.py
@@ -7,6 +7,7 @@ from odoo.tools import html_sanitize
 
 
 class OdooModule(models.Model):
+    _inherit = "abstract.action.mixin"
     _name = "odoo.module"
     _description = "Odoo Module"
     _order = "technical_name, name"

--- a/github_connector_odoo/views/view_github_repository_branch.xml
+++ b/github_connector_odoo/views/view_github_repository_branch.xml
@@ -26,12 +26,12 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
         <field name="arch" type="xml">
             <xpath expr="//div[@name='button_box']" position="inside">
                 <button
-                    type="action"
+                    type="object"
                     class="oe_stat_button"
                     icon="fa-cube"
-                    name="%(action_odoo_module_version)d"
+                    name="action_open"
                     attrs="{'invisible': [('module_version_qty', '=', False)]}"
-                    context="{'search_default_repository_branch_id': active_id}"
+                    context="{'xml_id': 'action_odoo_module_version', 'field_name': 'repository_branch_id'}"
                 >
                     <field
                         name="module_version_qty"

--- a/github_connector_odoo/views/view_odoo_author.xml
+++ b/github_connector_odoo/views/view_odoo_author.xml
@@ -29,12 +29,12 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                 <sheet>
                     <div class="oe_button_box" name="button_box">
                         <button
-                            type="action"
-                            name="%(action_odoo_module)d"
+                            type="object"
+                            name="action_open"
                             class="oe_stat_button"
                             icon="fa-cubes"
                             attrs="{'invisible': [('module_qty', '=', False)]}"
-                            context="{'search_default_author_ids': active_id}"
+                            context="{'xml_id': 'action_odoo_module', 'field_name': 'author_ids'}"
                         >
                             <field
                                 name="module_qty"

--- a/github_connector_odoo/views/view_odoo_lib_bin.xml
+++ b/github_connector_odoo/views/view_odoo_lib_bin.xml
@@ -29,12 +29,12 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                 <sheet>
                     <div class="oe_button_box" name="button_box">
                         <button
-                            type="action"
-                            name="%(action_odoo_module_version)d"
+                            type="object"
+                            name="action_open"
                             class="oe_stat_button"
                             icon="fa-cube"
                             attrs="{'invisible': [('module_version_qty', '=', False)]}"
-                            context="{'search_default_license_id': active_id}"
+                            context="{'xml_id': 'action_odoo_module_version', 'field_name': 'lib_bin_ids'}"
                         >
                             <field
                                 name="module_version_qty"

--- a/github_connector_odoo/views/view_odoo_lib_python.xml
+++ b/github_connector_odoo/views/view_odoo_lib_python.xml
@@ -29,12 +29,12 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                 <sheet>
                     <div class="oe_button_box" name="button_box">
                         <button
-                            type="action"
-                            name="%(action_odoo_module_version)d"
+                            type="object"
+                            name="action_open"
                             class="oe_stat_button"
                             icon="fa-cube"
                             attrs="{'invisible': [('module_version_qty', '=', False)]}"
-                            context="{'search_default_license_id': active_id}"
+                            context="{'xml_id': 'action_odoo_module_version', 'field_name': 'lib_python_ids'}"
                         >
                             <field
                                 name="module_version_qty"

--- a/github_connector_odoo/views/view_odoo_license.xml
+++ b/github_connector_odoo/views/view_odoo_license.xml
@@ -29,12 +29,12 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                 <sheet>
                     <div class="oe_button_box" name="button_box">
                         <button
-                            type="action"
-                            name="%(action_odoo_module_version)d"
+                            type="object"
+                            name="action_open"
                             class="oe_stat_button"
                             icon="fa-cube"
                             attrs="{'invisible': [('module_version_qty', '=', False)]}"
-                            context="{'search_default_license_id': active_id}"
+                            context="{'xml_id': 'action_odoo_module_version', 'field_name': 'license_id'}"
                         >
                             <field
                                 name="module_version_qty"

--- a/github_connector_odoo/views/view_odoo_module.xml
+++ b/github_connector_odoo/views/view_odoo_module.xml
@@ -41,12 +41,12 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                 <sheet>
                     <div class="oe_button_box" name="button_box">
                         <button
-                            type="action"
-                            name="%(action_odoo_module_version)d"
+                            type="object"
+                            name="action_open"
                             class="oe_stat_button"
                             icon="fa-cube"
                             attrs="{'invisible': [('module_version_qty', '=', False)]}"
-                            context="{'search_default_module_id': active_id}"
+                            context="{'xml_id': 'action_odoo_module_version', 'field_name': 'module_id'}"
                         >
                             <field
                                 name="module_version_qty"
@@ -55,12 +55,12 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                             />
                         </button>
                         <button
-                            type="action"
-                            name="%(action_odoo_module_version)d"
+                            type="object"
+                            name="action_open"
                             class="oe_stat_button"
                             icon="fa-arrows-v"
                             attrs="{'invisible': [('dependence_module_version_qty', '=', False)]}"
-                            context="{'search_default_dependency_module_ids': active_id}"
+                            context="{'xml_id': 'action_odoo_module_version', 'field_name': 'dependency_module_ids'}"
                         >
                             <field
                                 name="dependence_module_version_qty"


### PR DESCRIPTION
This PR solve the problem that exists when push in "Modules" button from Repository branch menu.

Please, @pedrobaeza review it

@Tecnativa TT25565