### PR TITLE
[13.0][FIX] github_connector: Use correct error messages

### DIFF
--- a/github_connector/models/github.py
+++ b/github_connector/models/github.py
@@ -103,22 +103,26 @@ class Github(object):
         else:
             raise exceptions.Warning(_("Maximum attempts reached."))
 
+        if isinstance(self.auth, HTTPBasicAuth):
+            auth_err_msg = _("login '%s'") % self.auth.login
+        elif isinstance(self.auth, HTTPTokenAuth):
+            auth_err_msg = _("provided token")
         if response.status_code == _CODE_401:
             raise exceptions.Warning(
                 _(
-                    "401 - Unable to authenticate to Github with the login '%s'.\n"
+                    "401 - Unable to authenticate to Github with the %s.\n"
                     "You should check your credentials in the Odoo"
                     " configuration file."
                 )
-                % self.login
+                % auth_err_msg
             )
         elif response.status_code == _CODE_403:
             raise exceptions.Warning(
                 _(
-                    "Unable to realize the current operation. The login '%s'"
+                    "Unable to realize the current operation. The %s"
                     " does not have the correct access rights."
                 )
-                % self.login
+                % auth_err_msg
             )
         elif response.status_code == _CODE_422:
             raise exceptions.Warning(


### PR DESCRIPTION
The error message on a failed login depends on the GH auth method being used.
If the user selected a token, there won't be a login to show the error in the exception thrown.
This makes the error message adapt to the type of auth chosen.

@Tecnativa
TT30343

ping @pedrobaeza @CarlosRoca13 