### PR TITLE
[14.0][FIX] github_connector: migration scripts

### DIFF
--- a/github_connector/migrations/14.0.1.0.0/pre-migration.py
+++ b/github_connector/migrations/14.0.1.0.0/pre-migration.py
@@ -2,29 +2,22 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from openupgradelib import openupgrade
 
-column_renames = {
-    "res_partner": [
-        ("github_team_ids", "github_team_partner_ids"),
-        ("github_login", "github_name"),
-    ],
-    "github_organization": [
-        ("github_login", "github_name"),
-    ],
-    "github_repository_branch": [
-        ("github_login", "github_name"),
-    ],
-    "github_repository": [
-        ("github_login", "github_name"),
-    ],
-    "github_team_partner": [
-        ("github_login", "github_name"),
-    ],
-    "github_team": [
-        ("github_login", "github_name"),
-    ],
-}
+field_renames = [
+    ("res.partner", "res_partner", "github_team_ids", "github_team_partner_ids"),
+    ("res.partner", "res_partner", "github_login", "github_name"),
+    ("github.organization", "github_organization", "github_login", "github_name"),
+    (
+        "github.repository.branch",
+        "github_repository_branch",
+        "github_login",
+        "github_name",
+    ),
+    ("github.repository", "github_repository", "github_login", "github_name"),
+    ("github.team.partner", "github_team_partner", "github_login", "github_name"),
+    ("github.team", "github_team", "github_login", "github_name"),
+]
 
 
 @openupgrade.migrate()
 def migrate(env, version):
-    openupgrade.rename_columns(env.cr, column_renames)
+    openupgrade.rename_fields(env, field_renames)


### PR DESCRIPTION
If not, migration breaks as github_team_ids column doesn't exist.