### PR TITLE
[15.0][FIX] github_connector: Set the correct "up to date" response to the git pull command

### DIFF
--- a/github_connector/models/github_repository_branch.py
+++ b/github_connector/models/github_repository_branch.py
@@ -192,15 +192,10 @@ class GithubRepository(models.Model):
                     res = check_output(
                         ["git", "pull", "origin", branch.name], cwd=branch.local_path
                     )
-                    if branch.state == "to_download" or b"up-to-date" not in res:
-                        branch.write(
-                            {
-                                "last_download_date": datetime.today(),
-                                "state": "to_analyze",
-                            }
-                        )
-                    else:
-                        branch.write({"last_download_date": datetime.today()})
+                    vals = {"last_download_date": datetime.today()}
+                    if b"up to date" not in res:
+                        vals["state"] = "to_analyze"
+                    branch.write(vals)
                 except Exception:
                     # Trying to clean the local folder
                     _logger.warning(


### PR DESCRIPTION
Set the correct "_up to date_" response to the `git pull` command

@Tecnativa TT25583