### PR TITLE
[IMP] github_connector: Repository and Branch Many2One usability

### DIFF
--- a/github_connector/__manifest__.py
+++ b/github_connector/__manifest__.py
@@ -6,7 +6,7 @@
 {
     "name": "Github Connector",
     "summary": "Synchronize information from Github repositories",
-    "version": "14.0.2.1.0",
+    "version": "14.0.2.2.0",
     "category": "Connector",
     "license": "AGPL-3",
     "author": "Odoo Community Association (OCA), GRAP, Akretion, Tecnativa",

--- a/github_connector/migrations/14.0.2.2.0/post-migration.py
+++ b/github_connector/migrations/14.0.2.2.0/post-migration.py
@@ -1,0 +1,20 @@
+#  Copyright 2023 Simone Rubino - Aion Tech
+#  License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    branches = env["github.repository.branch"].search([])
+    repositories = branches.repository_id
+    repositories.modified(
+        [
+            "complete_name",
+        ]
+    )
+    branches.recompute(
+        fnames=[
+            "complete_name",
+        ],
+    )

--- a/github_connector/models/github_repository.py
+++ b/github_connector/models/github_repository.py
@@ -15,6 +15,7 @@ class GithubRepository(models.Model):
     _inherit = ["abstract.github.model"]
     _order = "organization_id, name"
     _description = "Github Repository"
+    _rec_name = "complete_name"
 
     _github_login_field = "full_name"
 

--- a/github_connector/readme/CONTRIBUTORS.rst
+++ b/github_connector/readme/CONTRIBUTORS.rst
@@ -11,3 +11,6 @@
   * Carlos Roca
   * Víctor Martínez
   * João Marques
+* `Aion Tech <https://aiontech.company/>`_:
+
+  * Simone Rubino <simone.rubino@aion-tech.it>

--- a/github_connector/tests/__init__.py
+++ b/github_connector/tests/__init__.py
@@ -1,4 +1,7 @@
 # Copyright 2021-2022 Tecnativa - Víctor Martínez
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from . import test_branch
 from . import test_github_connector
 from . import test_github_analysis_rule
+from . import test_repository

--- a/github_connector/tests/test_branch.py
+++ b/github_connector/tests/test_branch.py
@@ -1,0 +1,21 @@
+#  Copyright 2023 Simone Rubino - Aion Tech
+#  License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from .common import TestGithubConnectorCommon
+
+
+class TestBranch(TestGithubConnectorCommon):
+    def test_display_name(self):
+        """The display name shows
+        the Organization name,
+        the Repository name
+        and the Branch name.
+        """
+        branch = self.repository_ocb_13
+        repository = branch.repository_id
+        organization = repository.organization_id
+
+        display_name = branch.display_name
+        self.assertIn(branch.name, display_name)
+        self.assertIn(repository.name, display_name)
+        self.assertIn(organization.github_name, display_name)

--- a/github_connector/tests/test_repository.py
+++ b/github_connector/tests/test_repository.py
@@ -1,0 +1,18 @@
+#  Copyright 2023 Simone Rubino - Aion Tech
+#  License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from .common import TestGithubConnectorCommon
+
+
+class TestRepository(TestGithubConnectorCommon):
+    def test_display_name(self):
+        """The display name shows
+        the Organization name
+        and the Repository name.
+        """
+        repository = self.repository_ocb
+        organization = repository.organization_id
+
+        display_name = repository.display_name
+        self.assertIn(repository.name, display_name)
+        self.assertIn(organization.github_name, display_name)


### PR DESCRIPTION
Steps:

1. Sync different organizations, each having a fork of **OCA/interface-github**
2. download the **14.0** series for all the forks
3. open a Many2One for the branch

Actual result:
a long list of **interface-github/14.0** entries

Expected result:
list of entries where the organization is visible, like
- **OCA/interface-github/14.0**
- **SirAionTech/interface-github/14.0**
- ...


The same applies for any Many2One for Repositories: 

before this PR:
a long list of **interface-github** entries

after this PR:
list of entries where the organization is visible, like
- **OCA/interface-github**
- **SirAionTech/interface-github**
- ...
