### PR TITLE
[16.0][FIX] github_connector_odoo: Proper manifest and icon load

### DIFF
--- a/github_connector_odoo/models/github_repository_branch.py
+++ b/github_connector_odoo/models/github_repository_branch.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2016-Today: Odoo Community Association (OCA)
 # Copyright 2020-2023 Tecnativa - Víctor Martínez
+# Copyright 2024 Tecnativa - Pedro M. Baeza
 # @author: Sylvain LE GAL (https://twitter.com/legalsylvain)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
@@ -8,6 +9,8 @@ import os
 
 from odoo import api, fields, models
 from odoo.modules.module import get_manifest
+
+import odoo.addons
 
 # Hard define this value to make this module working with or without
 # the patch (that backports V10 manifests analysis code.
@@ -209,7 +212,9 @@ class GithubRepositoryBranch(models.Model):
             manifest_keys_find = module_version.manifest_key_ids.filtered(
                 lambda x: x.id in rule.manifest_key_ids.ids
             )
+            odoo.addons.__path__.append(full_path)  # HACK: to get file_open working
             module_info = get_manifest(module_version.technical_name, full_path)
+            odoo.addons.__path__.remove(full_path)
             spec = rule._set_spec(rule.paths.splitlines())
             for manifest_key_find in manifest_keys_find:
                 if manifest_key_find.name in module_info:
@@ -227,7 +232,9 @@ class GithubRepositoryBranch(models.Model):
         module_version_obj = self.env["odoo.module.version"]
         try:
             full_module_path = os.path.join(path, module_name)
+            odoo.addons.__path__.append(path)  # HACK: to get file_open working
             module_info = get_manifest(module_name, full_module_path)
+            odoo.addons.__path__.remove(path)
             # Create module version, if the module is installable
             # in the serie
             if module_info.get("installable", False):

--- a/github_connector_odoo/models/odoo_module_version.py
+++ b/github_connector_odoo/models/odoo_module_version.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2016-Today: Odoo Community Association (OCA)
 # @author: Sylvain LE GAL (https://twitter.com/legalsylvain)
+# Copyright 2024 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 import base64
@@ -495,11 +496,11 @@ class OdooModuleVersion(models.Model):
             try:
                 with open(icon_path, "rb") as f:
                     image = f.read()
-                image_enc = base64.b64encode(image)
                 if resize:
-                    image = tools.image.ImageProcess(image_enc, False)
-                    image.resize(96, 96)
-                    image_enc = image.image_base64(output_format="PNG")
+                    process = tools.image.ImageProcess(image, False)
+                    process.resize(96, 96)
+                    image = process.image_quality()
+                image_enc = base64.b64encode(image)
             except Exception:
                 _logger.warning("Unable to read or resize %s", icon_path)
             module_version.write({"image": image_enc})


### PR DESCRIPTION
- Internal implementation of get_manifest (with load_file/load_path) was rejecting the manifest path as not being in its addons_path.
- Image resizing was not done correctly.

@Tecnativa