### PR TITLE
[18.0][FIX] github_connector: Clean empty lines in path patterns before matching

### DIFF
--- a/github_connector/models/github_analysis_rule.py
+++ b/github_connector/models/github_analysis_rule.py
@@ -24,11 +24,13 @@ class GithubAnalysisRule(models.Model):
     )
 
     def _set_spec(self, lines):
-        return pathspec.PathSpec.from_lines("gitwildmatch", lines)
+        return pathspec.PathSpec.from_lines("gitignore", lines)
 
     def _get_matches(self, path):
         """
         Get all matches from rule paths (multiple per line allow in rule)
         in a local path
         """
-        return self._set_spec(self.paths.splitlines()).match_tree(path)
+        patterns = self.paths.splitlines()
+        patterns = [p.strip() for p in patterns if p.strip()]  # Clean empty lines
+        return self._set_spec(patterns).match_tree_files(path)

--- a/github_connector_odoo/models/github_analysis_rule.py
+++ b/github_connector_odoo/models/github_analysis_rule.py
@@ -20,7 +20,7 @@ class GithubAnalysisRule(models.Model):
         if self.has_odoo_addons:
             spec = self._set_spec(["*"])
             file_paths = []
-            for path_item in spec.match_tree(path):
+            for path_item in spec.match_tree_files(path):
                 file_paths.append(f"{path}/{path_item}")
             spec = self._set_spec(self.paths.splitlines())
             return spec.match_files(file_paths)


### PR DESCRIPTION
Before this commit, the matching was not done correctly because the result of splitlines() could contain empty lines or spaces.

<img width="674" height="226" alt="image" src="https://github.com/user-attachments/assets/57b7b80a-7590-43bb-b07e-a4d2b58e2768" />

<img width="1315" height="702" alt="image" src="https://github.com/user-attachments/assets/10808bc0-1431-46b7-a18a-e04c050cd5a2" />


See the https://github.com/cpburnz/python-pathspec/blob/v1.0.4/CHANGES.rst  from version 1.0.0 
TT60674
@Tecnativa @pedrobaeza @victoralmau could you please review this?
